### PR TITLE
Fix: Unsupported version error on Intellij

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,5 +23,4 @@ intellij {
 
 patchPluginXml {
     sinceBuild '162.00'
-    untilBuild '201.00'
 }


### PR DESCRIPTION
Removed untilBuild '201.00' from build.gradle